### PR TITLE
deb: prepare to coexist with flux-core package

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,11 +1,9 @@
-#!/bin/sh
+#!/bin/sh -v
 #
 # Run an extra libtoolize before autoreconf to ensure that
 # libtool macros can be found if libtool is in PATH, but its
 # macros are not in default aclocal search path.
 #
-echo "Running libtoolize --automake --copy ... "
 libtoolize --automake --copy || exit
-echo "Running autoreconf --verbose --install"
-autoreconf --verbose --install || exit
+autoreconf --force --verbose --install || exit
 echo "Now run ./configure."

--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,8 @@ Build-Depends:
   python3-ply,
   python3-sphinx
 
+Replaces: flux-core (<= 0.73.0)
+Breaks: flux-core (<= 0.73.0)
 Homepage: https://github.com/flux-framework/flux-foundry
 Package: flux-foundry
 Architecture: any


### PR DESCRIPTION
deb: prepare to coexist with flux-core package
    
Problem: flux-foundry is spilt off from flux-core, so will conflict with versions that predate the split.
    
Add appropriate package metadata per
https://www.debian.org/doc/debian-policy/ch-relationships.html#syntax-of-relationship-fields
    
Fixes #5