### PR TITLE
ci: update typos checker version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Check Spelling
-      uses: crate-ci/typos@v1.35.5
+      uses: crate-ci/typos@v1.39.0
 
   build-macos:
     name: macos build only

--- a/src/liboptparse/optparse.c
+++ b/src/liboptparse/optparse.c
@@ -54,7 +54,7 @@ struct opt_parser {
     int            option_index;
 
     int            left_margin;     /* Size of --help output left margin    */
-    int            option_width;    /* Width of --help output for optiion   */
+    int            option_width;    /* Width of --help output for option   */
     int            current_group;   /* Current option group number          */
     zlist_t *      option_list;     /* List of options for this program     */
 


### PR DESCRIPTION
Problem: The crate-ci/typos version is out of date, so some new typos are not fixed.

Update crate-ci/typos to v1.39.0.

Fix one new typo caught by the checker.